### PR TITLE
Issue 29: Optional Distribution SHA 256 Sum warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ The default configuration should suit for most of the cases, however, there are 
     # Enable concurrent cache save and restore
     # Default is concurrent=false for better log readability
     concurrent: true
+
+    # Disable warning about missing distributionSha256Sum property in gradle-wrapper.properties
+    gradle-distribution-sha-256-sum-warning: false
 ```
 
 ## How does dependency caching work?

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,10 @@ inputs:
   properties:
     description: Extra Gradle properties (multiline) which would be passed as -Pname=value arguments
     required: false
+  gradle-distribution-sha-256-sum-warning:
+    description: Enables warning when distributionSha256Sum property is missing in gradle-wrapper.properties
+    required: false
+    default: 'true'
 runs:
   using: node12
   main: dist/cache-action-entrypoint.js

--- a/cache-action-entrypoint/src/main/kotlin/main.kt
+++ b/cache-action-entrypoint/src/main/kotlin/main.kt
@@ -99,6 +99,7 @@ suspend fun mainInternal(stage: ActionStage) {
         projectPath = params.path,
         distributionUrl = getInput("gradle-distribution-url").ifBlank { null },
         distributionSha256Sum = getInput("gradle-distribution-sha-256-sum").ifBlank { null },
+        enableDistributionSha256SumWarning = getInput("gradle-distribution-sha-256-sum-warning").ifBlank { "true" }.toBoolean(),
     )
 
     if (stage == ActionStage.MAIN || stage == ActionStage.POST) {

--- a/gradle-launcher/src/main/kotlin/com/github/burrunan/launcher/GradleDistribution.kt
+++ b/gradle-launcher/src/main/kotlin/com/github/burrunan/launcher/GradleDistribution.kt
@@ -27,12 +27,13 @@ suspend fun resolveDistribution(
     projectPath: String,
     distributionUrl: String? = null,
     distributionSha256Sum: String? = null,
+    enableDistributionSha256SumWarning: Boolean = true
 ): GradleDistribution {
     return if (distributionUrl == null) {
         when (val version = GradleVersion(versionSpec)) {
             is GradleVersion.Official -> version.findUrl()
             is GradleVersion.Dynamic -> version.findUrl()
-            is GradleVersion.Wrapper -> findVersionFromWrapper(projectPath)
+            is GradleVersion.Wrapper -> findVersionFromWrapper(projectPath, enableDistributionSha256SumWarning)
         }
     } else {
         GradleDistribution(

--- a/gradle-launcher/src/main/kotlin/com/github/burrunan/launcher/GradleInstaller.kt
+++ b/gradle-launcher/src/main/kotlin/com/github/burrunan/launcher/GradleInstaller.kt
@@ -103,7 +103,7 @@ suspend fun GradleVersionResponse.resolveChecksum() =
         distributionSha256Sum = HttpClient().get(checksumUrl, HTTP_AGENT).await().readBody().await().trim(),
     )
 
-suspend fun findVersionFromWrapper(projectPath: String): GradleDistribution {
+suspend fun findVersionFromWrapper(projectPath: String, enableDistributionSha256SumWarning: Boolean): GradleDistribution {
     val gradleWrapperProperties = path.join(projectPath, "gradle", "wrapper", "gradle-wrapper.properties")
     if (!exists(gradleWrapperProperties)) {
         warning("Gradle wrapper configuration is not found at ${path.resolve(gradleWrapperProperties)}.\nWill use the current release Gradle version")
@@ -123,7 +123,7 @@ suspend fun findVersionFromWrapper(projectPath: String): GradleDistribution {
         .removeSuffix("-bin.zip")
         .removeSuffix(".zip")
 
-    if (distributionSha256Sum == null) {
+    if (enableDistributionSha256SumWarning && distributionSha256Sum == null) {
         warning(
             "distributionSha256Sum is not set in $gradleWrapperProperties.\n" +
                 "Please consider adding the checksum, " +


### PR DESCRIPTION
makes the report of distributionSha256Sum warning optional
https://github.com/burrunan/gradle-cache-action/issues/29

This property is not fully supported in current Android Studio version