### PR TITLE
fix: bumps Node.js verstion to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ inputs:
     required: false
     default: 'true'
 runs:
-  using: node12
+  using: node16
   main: dist/cache-action-entrypoint.js
   post: dist/cache-action-entrypoint.js
 branding:


### PR DESCRIPTION
Should close the following issue https://github.com/burrunan/gradle-cache-action/issues/50