### PR TITLE
Also consider nested version catalogs in default dependency paths

### DIFF
--- a/layered-cache/src/main/kotlin/com/github/burrunan/gradle/cache/dependenciesCache.kt
+++ b/layered-cache/src/main/kotlin/com/github/burrunan/gradle/cache/dependenciesCache.kt
@@ -70,7 +70,7 @@ suspend fun gradleDependenciesCache(trigger: ActionsTrigger, path: String, gradl
             "$path/**/*.gradle.kts",
             "$path/**/gradle/dependency-locking/**",
             "$path/**/*.properties",
-            "$path/gradle/libs.versions.toml",
+            "$path/**/gradle/libs.versions.toml",
         ) + gradleDependenciesCacheKey.map {
                 (if (it.startsWith("!")) "!" else "") +
                     "$path/**/" + it.trim().trimStart('!')


### PR DESCRIPTION
I came to the conclusion that my previous PR was too opinionated.
I usually just have one version catalog and also use that in nested builds.
But it imho makes sense to also consider the default version catalog file
of nested builds in the worktree.
