### PR TITLE
Run action using Node.js 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ inputs:
     required: false
     default: 'true'
 runs:
-  using: node16
+  using: node20
   main: dist/cache-action-entrypoint.js
   post: dist/cache-action-entrypoint.js
 branding:


### PR DESCRIPTION
Node.js 16 is deprecated on GitHub Actions. See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/