### PR TITLE
chore: add missing 'daemon' input to action-types.yml

### DIFF
--- a/action-types.yml
+++ b/action-types.yml
@@ -45,6 +45,8 @@ inputs:
       type: string
   debug:
     type: boolean
+  daemon:
+    type: boolean
   concurrent:
     type: boolean
   arguments:


### PR DESCRIPTION
## Summary

- The `daemon` input is declared in `action.yml` but missing from `action-types.yml`.
- The Check Action Typing job (krzema12 v2.2.2) reports it as INVALID, blocking PRs that touch `action.yml` such as #150 (Node 24 migration).
- This PR adds the missing entry.

## Test plan

- [ ] CI passes (Build, Validation, Check Action Typing)
- [ ] After this lands, re-run #150 CI to verify it can pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)