### PR TITLE
chore: refine renovate automerge config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
   ],
   "automerge": true,
   "platformAutomerge": true,
+  "automergeSchedule": ["at any time"],
+  "rebaseWhen": "behind-base-branch",
   "labels": ["dependencies"],
   "schedule": ["every 1 weeks on Monday"]
 }


### PR DESCRIPTION
## Summary
- `automergeSchedule: ["at any time"]` — automerge fires as soon as Build is green, instead of waiting for the next Monday window (the weekly `schedule` still gates PR *creation*).
- `rebaseWhen: "behind-base-branch"` — Renovate auto-rebases PRs when `main` advances, which keeps platform automerge unblocked.

## Context
Repository-side prerequisites for `platformAutomerge: true` are now in place (Allow auto-merge, delete-branch-on-merge, allow-update-branch, and the `protect main branch` ruleset is now actually scoped to `~DEFAULT_BRANCH`).

## Test plan
- [x] `renovate-config-validator` passes locally
- [ ] CI `Build` green
- [ ] Next Renovate PR opens with `autoMergeRequest != null` and merges itself once Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)