### PR TITLE
fix(deps): update kotlin-wrappers to v2026 (with imports fix)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ allprojects {
         dependencies {
             "commonMainApi"(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.11.0"))
             "commonMainApi"(platform("org.jetbrains.kotlinx:kotlinx-serialization-bom:1.11.0"))
-            "jsMainImplementation"(enforcedPlatform("org.jetbrains.kotlin-wrappers:kotlin-wrappers-bom:2025.12.12"))
+            "jsMainImplementation"(enforcedPlatform("org.jetbrains.kotlin-wrappers:kotlin-wrappers-bom:2026.5.6"))
             if (project.path != ":test-library") {
                 "jsTestImplementation"(rootProject.projects.testLibrary)
             }

--- a/cache-action-entrypoint/src/jsMain/kotlin/main.kt
+++ b/cache-action-entrypoint/src/jsMain/kotlin/main.kt
@@ -32,6 +32,7 @@ import com.github.burrunan.launcher.resolveDistribution
 import com.github.burrunan.wrappers.nodejs.normalizedPath
 import js.globals.globalThis
 import node.buffer.BufferEncoding
+import node.buffer.utf8
 import node.fs.writeFile
 import node.path.path
 import node.process.process

--- a/cache-proxy/src/jsTest/kotlin/com/github/burrunan/gradle/proxy/CacheProxyTest.kt
+++ b/cache-proxy/src/jsTest/kotlin/com/github/burrunan/gradle/proxy/CacheProxyTest.kt
@@ -25,6 +25,7 @@ import com.github.burrunan.wrappers.nodejs.mkdir
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToDynamic
 import node.buffer.BufferEncoding
+import node.buffer.utf8
 import node.fs.copyFile
 import node.fs.writeFile
 import node.process.process

--- a/gradle-launcher/src/jsMain/kotlin/com/github/burrunan/launcher/GradleInstaller.kt
+++ b/gradle-launcher/src/jsMain/kotlin/com/github/burrunan/launcher/GradleInstaller.kt
@@ -38,6 +38,7 @@ import node.fs.readFile
 import node.http.OutgoingHttpHeaders
 import node.path.path
 import node.process.Platform
+import node.process.win32
 
 class GradleWrapperNotFound(override val message: String, cause: Throwable? = null) :
     Throwable(message, cause)

--- a/gradle-launcher/src/jsMain/kotlin/com/github/burrunan/launcher/GradleInstaller.kt
+++ b/gradle-launcher/src/jsMain/kotlin/com/github/burrunan/launcher/GradleInstaller.kt
@@ -32,6 +32,7 @@ import js.promise.await
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import node.buffer.BufferEncoding
+import node.buffer.utf8
 import node.fs.chmod
 import node.fs.readFile
 import node.http.OutgoingHttpHeaders

--- a/hashing/src/jsMain/kotlin/com/github/burrunan/hashing/HashDetails.kt
+++ b/hashing/src/jsMain/kotlin/com/github/burrunan/hashing/HashDetails.kt
@@ -23,6 +23,7 @@ import js.promise.await
 import kotlinx.serialization.Serializable
 import node.crypto.BinaryToTextEncoding
 import node.crypto.createHash
+import node.crypto.hex
 import node.fs.createReadStream
 import node.fs.stat
 import node.process.process

--- a/hashing/src/jsMain/kotlin/com/github/burrunan/hashing/hashFiles.kt
+++ b/hashing/src/jsMain/kotlin/com/github/burrunan/hashing/hashFiles.kt
@@ -22,8 +22,10 @@ import com.github.burrunan.wrappers.nodejs.pipeAndWait
 import js.promise.await
 import node.WritableStream
 import node.buffer.BufferEncoding
+import node.buffer.utf8
 import node.crypto.BinaryToTextEncoding
 import node.crypto.createHash
+import node.crypto.hex
 import node.fs.createReadStream
 import node.fs.stat
 import node.process.process

--- a/layered-cache/src/jsMain/kotlin/com/github/burrunan/gradle/cache/MetadataFile.kt
+++ b/layered-cache/src/jsMain/kotlin/com/github/burrunan/gradle/cache/MetadataFile.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import node.buffer.BufferEncoding
+import node.buffer.utf8
 import node.fs.*
 
 class MetadataFile<T>(name: String, private val serializer: KSerializer<T>, private val extension: String = ".json") {

--- a/layered-cache/src/jsTest/kotlin/com/github/burrunan/gradle/CacheServerTest.kt
+++ b/layered-cache/src/jsTest/kotlin/com/github/burrunan/gradle/CacheServerTest.kt
@@ -24,6 +24,7 @@ import com.github.burrunan.gradle.cache.LayeredCache
 import com.github.burrunan.test.runTest
 import com.github.burrunan.wrappers.nodejs.mkdir
 import node.buffer.BufferEncoding
+import node.buffer.utf8
 import node.fs.readFile
 import node.fs.unlink
 import node.fs.writeFile

--- a/layered-cache/src/jsTest/kotlin/com/github/burrunan/gradle/GlobTest.kt
+++ b/layered-cache/src/jsTest/kotlin/com/github/burrunan/gradle/GlobTest.kt
@@ -21,6 +21,7 @@ import com.github.burrunan.hashing.hashFilesDetailed
 import com.github.burrunan.test.runTest
 import com.github.burrunan.wrappers.nodejs.mkdir
 import node.buffer.BufferEncoding
+import node.buffer.utf8
 import node.fs.writeFile
 import node.path.path
 import kotlin.test.Test

--- a/wrappers/octokit-webhooks/src/jsMain/kotlin/octokit/ActionsTrigger.kt
+++ b/wrappers/octokit-webhooks/src/jsMain/kotlin/octokit/ActionsTrigger.kt
@@ -17,6 +17,7 @@ package octokit
 
 import actions.core.ActionsEnvironment
 import node.buffer.BufferEncoding
+import node.buffer.utf8
 import node.fs.readFile
 import octokit.webhooks.WebhookPayloadPullRequest
 import octokit.webhooks.WebhookPayloadPush


### PR DESCRIPTION
## Summary

Supersedes #141 — Renovate's plain version bump doesn't compile against kotlin-wrappers v2026 because the `BufferEncoding`/`BinaryToTextEncoding` enum-like values became inline extension properties on the companion object and now must be imported explicitly.

This PR contains both:
- the version bump from #141 (`kotlin-wrappers-bom` 2025.12.12 → 2026.5.6), and
- import additions (`node.buffer.utf8`, `node.crypto.hex`) in 9 files so `BufferEncoding.utf8` and `BinaryToTextEncoding.hex` resolve again.

Closes #141.

## Test plan

- [x] `./gradlew --quiet compileKotlinJs` passes locally
- [ ] CI Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)