### PR TITLE
ci: replace deprecated wrapper-validation-action with gradle/actions/wrapper-validation

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3
+      - uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0


### PR DESCRIPTION
## Summary

- `gradle/wrapper-validation-action@v3` is deprecated and runs on Node 20 (being phased out of GitHub-hosted runners).
- Switch to `gradle/actions/wrapper-validation@v6.1.0`, the supported successor that runs on Node 24. The old action's README explicitly recommends this migration.

## Test plan

- [ ] Validation job runs on Node 24 (no deprecation warning)
- [ ] Validation passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)