### PR TITLE
docs: explain that the Gradle distribution is not cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,31 @@ proxy-based remote cache idea proved out. The implementation is Kotlin throughou
 Yes, you can. If you omit `arguments:`, then the action runs in `cache-only` mode.
 It won't launch Gradle.
 
+## Is the Gradle distribution itself cached?
+
+The action does not cache the downloaded Gradle distribution (`~/.gradle/wrapper/dists`).
+It caches the parts of the Gradle User Home that builds reuse: dependencies (`caches/modules-2`),
+the local build cache (`caches/build-cache-1`), generated Gradle jars, and the Maven repository (`~/.m2/repository`).
+
+How the distribution is handled depends on how you run Gradle:
+
+- **You run `./gradlew` yourself** (no `arguments:`). The wrapper downloads and unpacks the distribution on every run,
+  and the action does not cache it.
+- **The action runs Gradle** (`arguments:` is set). Gradle is installed into the runner tool cache (`RUNNER_TOOL_CACHE`).
+  Self-hosted runners keep that cache between runs, so the distribution is reused without another download.
+  GitHub-hosted runners start clean each run, so it is downloaded again.
+
+Caching the distribution rarely pays off: both a fresh download and a cache restore still unpack an archive of similar
+size, so the only difference is the download source. If your case is different, you can try a separate `actions/cache`
+step. Open an issue if it measurably helps, so we can understand when distribution caching is worthwhile:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: ~/.gradle/wrapper/dists
+    key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+```
+
 ## Can I call multiple different Gradle builds in the same job?
 
 This might be complicated, see https://github.com/burrunan/gradle-cache-action/issues/15.


### PR DESCRIPTION
## Why

[#163](https://github.com/burrunan/gradle-cache-action/issues/163) reported that the Gradle distribution is downloaded again on every run. That is expected: the action caches the Gradle User Home entries that builds reuse (`caches/modules-2`, `caches/build-cache-1`, generated Gradle jars, `~/.m2/repository`), but not the distribution under `~/.gradle/wrapper/dists`. The README did not state this, so the behavior looked like a bug.

## What

Add an FAQ entry, **"Is the Gradle distribution itself cached?"**, that documents:

- which paths the action caches, and that the distribution is not one of them;
- how the distribution is handled when you run `./gradlew` yourself (the wrapper downloads and unpacks it each run) versus when the action runs Gradle via `arguments:` (Gradle goes into `RUNNER_TOOL_CACHE`, reused on self-hosted runners, re-downloaded on GitHub-hosted ones);
- why caching the distribution rarely helps: both a fresh download and a cache restore still unpack an archive of similar size;
- an `actions/cache` snippet to try, with a request to open an issue if it measurably helps.

## How to verify

Docs-only change. Read the new section in `README.md` (between "Can I use the caching part of the action only?" and "Can I call multiple different Gradle builds in the same job?").

🤖 Generated with [Claude Code](https://claude.com/claude-code)