### PR TITLE
docs: note distribution caching competes for the 10 GB cache limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,10 @@ How the distribution is handled depends on how you run Gradle:
   GitHub-hosted runners start clean each run, so it is downloaded again.
 
 Caching the distribution rarely pays off: both a fresh download and a cache restore still unpack an archive of similar
-size, so the only difference is the download source. If your case is different, you can try a separate `actions/cache`
-step. Open an issue if it measurably helps, so we can understand when distribution caching is worthwhile:
+size, so the only difference is the download source. It also competes for the 10 GB per-repository GitHub Actions cache
+limit, where the distribution can crowd out more valuable entries such as `modules-2` and `build-cache-1`. If your case
+is different, you can try a separate `actions/cache` step. Open an issue if it measurably helps, so we can understand
+when distribution caching is worthwhile:
 
 ```yaml
 - uses: actions/cache@v4


### PR DESCRIPTION
## Why

Follow-up to #164. The distribution-caching FAQ explained that caching the Gradle distribution rarely saves time, but it did not mention the storage cost.

## What

Add one sentence to the **"Is the Gradle distribution itself cached?"** section: storing the distribution in the GitHub Actions cache competes for the 10 GB per-repository limit and can crowd out more valuable entries such as `modules-2` and `build-cache-1`.

## How to verify

Docs-only change. Read the updated paragraph in `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)