### PR TITLE
fix: keep a cache-proxy cleanup race from killing the build

### DIFF
--- a/cache-proxy/src/jsMain/kotlin/com/github/burrunan/gradle/proxy/CacheProxy.kt
+++ b/cache-proxy/src/jsMain/kotlin/com/github/burrunan/gradle/proxy/CacheProxy.kt
@@ -19,12 +19,14 @@ package com.github.burrunan.gradle.proxy
 import actions.cache.RestoreType
 import actions.cache.restoreAndLog
 import actions.core.LogLevel
+import actions.core.warning
 import actions.glob.removeFiles
 import com.github.burrunan.gradle.cache.HttpException
 import com.github.burrunan.gradle.cache.handle
 import com.github.burrunan.wrappers.nodejs.mkdir
 import com.github.burrunan.wrappers.nodejs.pipeAndWait
 import js.objects.unsafeJso
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import node.fs.createReadStream
@@ -50,6 +52,14 @@ class CacheProxy {
 
     val cacheUrl: String? get() = _cacheUrl
 
+    // The store runs detached so the PUT can be answered before the upload finishes, which leaves
+    // its failures with nowhere to go: without a handler they reach the uncaught-coroutine handler
+    // and terminate the process along with the Gradle build the action is running. A build cache
+    // entry that fails to store is not worth failing a build over.
+    private val storeExceptionHandler = CoroutineExceptionHandler { _, e ->
+        warning("Unable to store the build cache entry: ${e.message}")
+    }
+
     private val server = node.http.createServer<IncomingMessage, ServerResponse<*>> { req, res ->
         val query = node.url.parse(req.url!!, true)
         val path = query.pathname ?: ""
@@ -71,7 +81,7 @@ class CacheProxy {
             req.pipeAndWait(createWriteStream(fileName))
             res.writeHead(200, "OK", undefined.unsafeCast<OutgoingHttpHeaders>())
         } finally {
-            GlobalScope.launch {
+            GlobalScope.launch(storeExceptionHandler) {
                 try {
                     actions.cache.saveAndLog(listOf(fileName), id, cacheVersion, logLevel = LogLevel.DEBUG)
                 } finally {

--- a/layered-cache/src/jsTest/kotlin/com/github/burrunan/gradle/RemoveFilesTest.kt
+++ b/layered-cache/src/jsTest/kotlin/com/github/burrunan/gradle/RemoveFilesTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Vladimir Sitnikov <sitnikov.vladimir@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.burrunan.gradle
+
+import actions.glob.removeFiles
+import com.github.burrunan.test.runTest
+import com.github.burrunan.wrappers.nodejs.mkdir
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import node.buffer.BufferEncoding
+import node.buffer.utf8
+import node.fs.existsSync
+import node.fs.writeFile
+import node.path.path
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class RemoveFilesTest {
+    @Test
+    fun removesFilesConcurrentlyWithoutFailingOnAlreadyRemovedOnes() = runTest {
+        val dirName = "removeFilesTest"
+        mkdir(dirName)
+        val file = path.join(dirName, "bc-entry")
+        writeFile(file, "a", BufferEncoding.utf8)
+
+        // The cache proxy stores every payload for a given entry id under the same path and cleans
+        // it up from a detached coroutine, so cleanups race whenever an id is stored more than once.
+        coroutineScope {
+            List(4) { async { removeFiles(listOf(file)) } }.awaitAll()
+        }
+
+        assertFalse(existsSync(file), "$file should have been removed")
+    }
+}

--- a/wrappers/actions-toolkit/src/jsMain/kotlin/actions/glob/removeFiles.kt
+++ b/wrappers/actions-toolkit/src/jsMain/kotlin/actions/glob/removeFiles.kt
@@ -16,10 +16,12 @@
 
 package actions.glob
 
+import js.objects.unsafeJso
 import js.promise.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
-import node.fs.unlink
+import node.fs.RmOptions
+import node.fs.rm
 
 suspend fun removeFiles(files: List<String>) {
     if (files.isEmpty()) {
@@ -30,7 +32,9 @@ suspend fun removeFiles(files: List<String>) {
     supervisorScope {
         for (file in fileNames) {
             launch {
-                unlink(file)
+                // Concurrent cleanups can share a path, so a file may already be gone by the time
+                // this coroutine runs. force ignores that, whereas unlink would reject with ENOENT.
+                rm(file, unsafeJso<RmOptions> { force = true })
             }
         }
     }


### PR DESCRIPTION
Fixes #173.

## The race

`CacheProxy.putEntry` writes every payload for an entry id to the same path, `.cache-proxy/bc-<id>`, and then cleans it up from a coroutine launched in `GlobalScope`; `getEntry` restores into that same path. Nothing serialises the cleanups, so as soon as one id is stored more than once — which happens once the cache service throttles and the saves for one id overlap — two cleanups glob the same file and the second delete rejects with `ENOENT`.

`removeFiles` runs each delete in a `supervisorScope` child, which keeps its siblings alive but still propagates the failure to the enclosing scope. That scope is the unhandled `GlobalScope.launch`, so the rejection reaches Kotlin's uncaught-coroutine handler and terminates the Node process — together with the Gradle build the action is running. In the report the build was healthy and still streaming task output when it died.

## The fix

- `removeFiles` deletes with `rm(force = true)`. An already-deleted file is exactly the state the cleanup wants, so this is not error suppression: `force` skips the missing entry and every other failure still surfaces.
- The detached store gets a `CoroutineExceptionHandler` that logs a warning. A build cache entry that fails to upload should not be able to fail the build, and after this no failure in that coroutine can reach the uncaught handler.

Two small changes because they address different halves of the report: the first removes this particular exception, the second removes the crash path any future one would take.

## Test

`RemoveFilesTest` drives four concurrent `removeFiles` calls over one path. Against `main` it fails with the reported error:

```
ENOENT: no such file or directory, unlink ''
```

and passes with the fix. `./gradlew --no-parallel --no-daemon --build-cache build` is green.

`dist/` is untouched, since it is built on the `release` branch by CI.
