### PR TITLE
feat: allow pinning the remote build cache proxy port

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ The default configuration should suit most of the cases, however, there are extr
     # Disable remote cache that proxies requests to GitHub Actions cache
     remote-build-cache-proxy-enabled: false
 
+    # Pin the port the remote build cache proxy listens on. Default is 0, an ephemeral port.
+    # The port is written into the generated ~/.gradle/init.gradle, and Gradle fingerprints init
+    # script content, so an ephemeral port invalidates the configuration cache on every run. Pin it
+    # to reuse configuration cache entries across runs, keeping it unique per build on a shared machine
+    remote-build-cache-proxy-port: 34567
+
     # Set the cache key for Gradle version (e.g. in case multiple jobs use different versions)
     # By default the value is `wrapper`, so the version is determined from the gradle-wrapper.properties   
     # Note: this argument specifies the version for Gradle execution (if `arguments` is present)

--- a/action-types.yml
+++ b/action-types.yml
@@ -31,6 +31,8 @@ inputs:
     type: boolean
   remote-build-cache-proxy-enabled:
     type: boolean
+  remote-build-cache-proxy-port:
+    type: integer
   gradle-dependencies-cache-key:
     type: list
     separator: "\n"

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,15 @@ inputs:
     description: Activates a remote cache that proxies requests to GitHub Actions cache
     required: false
     default: 'true'
+  remote-build-cache-proxy-port:
+    description: >
+      Port for the remote build cache proxy. Defaults to 0, which picks an ephemeral port.
+      The port is written into the generated ~/.gradle/init.gradle, and Gradle treats init script
+      content as a configuration input, so an ephemeral port invalidates the configuration cache on
+      every run. Pin it to reuse configuration cache entries across runs, and make sure no two
+      builds sharing a machine pin the same port.
+    required: false
+    default: '0'
   gradle-dependencies-cache-key:
     description: Extra files to take into account for ~/.gradle/caches dependencies
     required: false

--- a/cache-action-entrypoint/src/jsMain/kotlin/main.kt
+++ b/cache-action-entrypoint/src/jsMain/kotlin/main.kt
@@ -151,7 +151,7 @@ suspend fun mainInternal(stage: ActionStage) {
             properties = getInput("properties").splitLines(),
         )
 
-        val cacheProxy = CacheProxy()
+        val cacheProxy = CacheProxy(port = getInput("remote-build-cache-proxy-port").ifBlank { "0" }.toInt())
 
         if (cacheProxyEnabled) {
             info("Starting remote cache proxy, adding it via ~/.gradle/init.gradle")

--- a/cache-proxy/src/jsMain/kotlin/com/github/burrunan/gradle/proxy/CacheProxy.kt
+++ b/cache-proxy/src/jsMain/kotlin/com/github/burrunan/gradle/proxy/CacheProxy.kt
@@ -39,7 +39,13 @@ import node.process.process
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
-class CacheProxy {
+/**
+ * @param port port to listen on, or 0 to pick an ephemeral one. The port ends up in the init script
+ * the proxy generates, and Gradle fingerprints init script content as a configuration input, so a
+ * port that changes between runs invalidates the configuration cache every time. Builds that want to
+ * reuse a configuration cache entry across runs need to pin it.
+ */
+class CacheProxy(private val port: Int = 0) {
     companion object {
         const val GHA_CACHE_URL = "GHA_CACHE_URL"
         private const val TEMP_DIR = ".cache-proxy"
@@ -178,7 +184,7 @@ class CacheProxy {
 
     suspend fun start() {
         suspendCoroutine<Nothing?> { cont ->
-            server.listen(0) {
+            server.listen(port) {
                 cont.resume(null)
             }
         }

--- a/cache-proxy/src/jsTest/kotlin/com/github/burrunan/gradle/proxy/CacheProxyTest.kt
+++ b/cache-proxy/src/jsTest/kotlin/com/github/burrunan/gradle/proxy/CacheProxyTest.kt
@@ -31,6 +31,9 @@ import node.fs.writeFile
 import node.process.process
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlin.test.fail
 
 class CacheProxyTest {
@@ -44,6 +47,27 @@ class CacheProxyTest {
     fun abc() = runTest {
         val z = mapOf("a" to 4, "b" to 6)
         println("json: " + JSON.stringify(Json.encodeToDynamic(z)))
+    }
+
+    @Test
+    fun pinnedPortReachesTheGeneratedInitScript() = runTest {
+        val port = 34567
+        val pinnedProxy = CacheProxy(port = port)
+        pinnedProxy {
+            assertEquals("http://localhost:$port/", pinnedProxy.cacheUrl)
+            assertContains(pinnedProxy.getMultiCacheConfiguration(), "url = 'http://localhost:$port/'")
+        }
+    }
+
+    @Test
+    fun ephemeralPortIsUsedByDefault() = runTest {
+        val ephemeralProxy = CacheProxy()
+        ephemeralProxy {
+            val url = ephemeralProxy.cacheUrl
+            assertNotNull(url)
+            val port = url.removePrefix("http://localhost:").removeSuffix("/").toInt()
+            assertTrue(port > 0, "an ephemeral port should have been assigned, got $url")
+        }
     }
 
     @Test


### PR DESCRIPTION
Adds `remote-build-cache-proxy-port` so the proxy can listen on a fixed port instead of an ephemeral one.

## Why

`CacheProxy.start()` calls `server.listen(0)`, and the assigned port is written into the `~/.gradle/init.gradle` the action generates:

```groovy
remote(HttpBuildCache) {
    url = 'http://localhost:41827/'
```

Gradle fingerprints init script *content* as a configuration input, so a port that changes every run invalidates the configuration cache every run:

```
Calculating task graph as configuration cache cannot be reused because init script 'init.gradle' has changed.
```

I confirmed it is the content and nothing else: with an init script left untouched between two builds Gradle reports `Reusing configuration cache`, and editing only the port in that same file produces the line above. Everything else in the generated script is derived from inputs that are stable across runs, so the port is the only reason the file differs.

Today that leaves a build choosing between the remote build cache proxy and a reusable configuration cache. On a multi-module Android project the configuration phase is 87 s on a test job and 157 s on an assemble job, of which the included build accounts for ~50 s, so giving up either side is expensive.

## The change

`CacheProxy` takes a port, defaulting to `0`, so **behaviour is unchanged unless the new input is set**. With it set the generated init script is byte-identical between runs and the configuration cache survives.

The input is opt-in rather than a fixed default on purpose: two builds pinning the same port on one machine would fail to bind. Ephemeral ports are the right default for self-hosted runners that run jobs concurrently, and the docs say so.

## Tests

Two cases in `CacheProxyTest`:
- `pinnedPortReachesTheGeneratedInitScript` — the pinned port appears in `cacheUrl` and in `getMultiCacheConfiguration()`
- `ephemeralPortIsUsedByDefault` — the default still gets an OS-assigned port

`./gradlew --no-parallel --no-daemon --build-cache build` is green, with all four `CacheProxyTest` cases passing including the existing end-to-end `cacheProxyWorks`.

`action-types.yml` and the README input list are updated. `dist/` is untouched, since it is built on the `release` branch by CI.
